### PR TITLE
Return after http.Error

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -38,6 +38,7 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	labelValue := q.Get(r.label)
 	if labelValue == "" {
 		http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
+		return
 	}
 	req.URL.Query().Del(r.label)
 
@@ -68,6 +69,7 @@ func (r *routes) federate(w http.ResponseWriter, req *http.Request) {
 	labelValue := q.Get(r.label)
 	if labelValue == "" {
 		http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
+		return
 	}
 	req.URL.Query().Del(r.label)
 


### PR DESCRIPTION
After writing with http.Error to the http.ResponseWriter we need to return.

/cc @s-urbaniak 