### PR TITLE
Add support for /api/v1/rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prom-label-proxy
 
-The prom-label-proxy enforces a given label in a given PromQL proxy.
+The prom-label-proxy can enforce a given label in a given PromQL query or in Prometheus API responses.
 
 This proxy does not perform authentication or authorization, this has to happen before the request reaches this proxy. The [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy) is an example for such an additional building block.
 
@@ -12,9 +12,17 @@ Risks outside the scope of this project:
 
 ## How does this project work?
 
-What this proxy does is it proxies the `/federate`, `/api/v1/query`, `/api/v1/query_range` prometheus endpoints and ensures that a particular label is enforced in the particular query.
+This application proxies the `/federate`, `/api/v1/query`, `/api/v1/query_range`, `/api/v1/rules` Prometheus endpoints and ensures that a particular label is enforced in the particular request and response.
 
-In the case of the federate endpoint, it ensures that all selectors passed as matchers to the federate endpoint _must_ contain that exact match of the particular label (and throws away all other matchers for the label). For the two query endpoints, it parses the PromQL expression and modifies all selectors in the same way. The label-key is configured as a flag on the binary and label-value is passed as a query parameter.
+Once again for clarity: this project only enforces a particular label in the respective calls to Prometheus, it in itself does not authenticate or authorize the requesting entity in any way, this has to be built around this project.
+
+### Federate endpoint
+
+The proxy ensures that all selectors passed as matchers to the `/federate` endpoint _must_ contain that exact match of the particular label (and throws away all other matchers for the label).
+
+### Query endpoints
+
+For the two query endpoints (`/api/v1/query` and `/api/v1/query_range`), the proxy parses the PromQL expression and modifies all selectors in the same way. The label-key is configured as a flag on the binary and the label-value is passed as a query parameter.
 
 For example, if requesting the PromQL query
 
@@ -31,7 +39,9 @@ http_requests_total{namespace="b"}
 
 This is enforced for any case, whether a label matcher is specified in the original query or not.
 
-Once again for clarity: this project only enforces a particular label in the respective calls to Prometheus, it in itself does not authenticate or authorize the requesting entity in any way, this has to be built around this project.
+### Rules endpoint
+
+The proxy requests the `/api/v1/rules` Prometheus endpoint, discards the rules that don't contain an exact match of the label and returns the modified response to the client.
 
 ## Example use
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/openshift/prom-label-proxy
 
 go 1.12
 
-require github.com/prometheus/prometheus v2.3.2+incompatible
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/prometheus/prometheus v2.3.2+incompatible
+)
 
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.0.0-20190818123050-43acd0e2e93f

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -1,47 +1,93 @@
 package injectproxy
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 )
 
 type routes struct {
-	handler http.Handler
-	label   string
+	handler    http.Handler
+	label      string
+	forwarders map[string]func(http.ResponseWriter, *http.Request)
+	modifiers  map[string]func(*http.Response) error
 }
 
-func NewRoutes(handler http.Handler, label string) *routes {
-	return &routes{
-		handler: handler,
+func NewRoutes(upstream *url.URL, label string) *routes {
+	proxy := httputil.NewSingleHostReverseProxy(upstream)
+
+	r := &routes{
+		handler: proxy,
 		label:   label,
 	}
+	r.forwarders = map[string]func(http.ResponseWriter, *http.Request){
+		"/federate":           r.federate,
+		"/api/v1/query":       r.query,
+		"/api/v1/query_range": r.query,
+		"/api/v1/rules":       r.noop,
+	}
+	r.modifiers = map[string]func(*http.Response) error{
+		"/api/v1/rules": r.rules,
+	}
+	proxy.ModifyResponse = r.ModifyResponse
+	return r
 }
 
 func (r *routes) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.URL.Path == "/api/v1/query" || req.URL.Path == "/api/v1/query_range" {
-		r.query(w, req)
-		return
-	}
-	if req.URL.Path == "/federate" {
-		r.federate(w, req)
+	h, found := r.forwarders[req.URL.Path]
+	if !found {
+		http.NotFound(w, req)
 		return
 	}
 
-	http.NotFound(w, req)
-}
-
-func (r *routes) query(w http.ResponseWriter, req *http.Request) {
-	q := req.URL.Query()
-	labelValue := q.Get(r.label)
-	if labelValue == "" {
+	lvalue := req.URL.Query().Get(r.label)
+	if lvalue == "" {
 		http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
 		return
 	}
+	req = req.WithContext(withLabelValue(req.Context(), lvalue))
 	req.URL.Query().Del(r.label)
 
+	h(w, req)
+}
+
+func (r *routes) ModifyResponse(resp *http.Response) error {
+	m, found := r.modifiers[resp.Request.URL.Path]
+	if !found {
+		return nil
+	}
+	return m(resp)
+}
+
+type ctxKey int
+
+const keyLabel ctxKey = iota
+
+func mustLabelValue(ctx context.Context) string {
+	label, ok := ctx.Value(keyLabel).(string)
+	if !ok {
+		panic(fmt.Sprintf("can't find the %q value in the context", keyLabel))
+	}
+	if label == "" {
+		panic(fmt.Sprintf("empty %q value in the context", keyLabel))
+	}
+	return label
+}
+
+func withLabelValue(ctx context.Context, label string) context.Context {
+	return context.WithValue(ctx, keyLabel, label)
+}
+
+func (r *routes) noop(w http.ResponseWriter, req *http.Request) {
+	r.handler.ServeHTTP(w, req)
+}
+
+func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	expr, err := promql.ParseExpr(req.FormValue("query"))
 	if err != nil {
 		return
@@ -51,13 +97,14 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 		{
 			Name:  r.label,
 			Type:  labels.MatchEqual,
-			Value: labelValue,
+			Value: mustLabelValue(req.Context()),
 		},
 	})
 	if err != nil {
 		return
 	}
 
+	q := req.URL.Query()
 	q.Set("query", expr.String())
 	req.URL.RawQuery = q.Encode()
 
@@ -65,20 +112,13 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *routes) federate(w http.ResponseWriter, req *http.Request) {
-	q := req.URL.Query()
-	labelValue := q.Get(r.label)
-	if labelValue == "" {
-		http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
-		return
-	}
-	req.URL.Query().Del(r.label)
-
 	matcher := &labels.Matcher{
 		Name:  r.label,
 		Type:  labels.MatchEqual,
-		Value: labelValue,
+		Value: mustLabelValue(req.Context()),
 	}
 
+	q := req.URL.Query()
 	q.Set("match[]", "{"+matcher.String()+"}")
 	req.URL.RawQuery = q.Encode()
 

--- a/injectproxy/rules.go
+++ b/injectproxy/rules.go
@@ -1,0 +1,187 @@
+package injectproxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+type apiResponse struct {
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data,omitempty"`
+	ErrorType string          `json:"errorType,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	Warnings  []string        `json:"warnings,omitempty"`
+}
+
+func getAPIResponse(resp *http.Response) (*apiResponse, error) {
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var apir apiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apir); err != nil {
+		return nil, err
+	}
+
+	if apir.Status != "success" {
+		return nil, fmt.Errorf("unexpected response status: %q", apir.Status)
+	}
+
+	return &apir, nil
+}
+
+func (a *apiResponse) setData(v interface{}) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	a.Data = json.RawMessage(b)
+	return nil
+}
+
+type rulesData struct {
+	RuleGroups []*ruleGroup `json:"groups"`
+}
+
+type ruleGroup struct {
+	Name     string  `json:"name"`
+	File     string  `json:"file"`
+	Rules    []rule  `json:"rules"`
+	Interval float64 `json:"interval"`
+}
+
+type rule struct {
+	*alertingRule
+	*recordingRule
+}
+
+func (r *rule) Labels() labels.Labels {
+	if r.alertingRule != nil {
+		return r.alertingRule.Labels
+	}
+	return r.recordingRule.Labels
+}
+
+// MarshalJSON implements the json.Marshaler interface for rule.
+func (r *rule) MarshalJSON() ([]byte, error) {
+	if r.alertingRule != nil {
+		return json.Marshal(r.alertingRule)
+	}
+	return json.Marshal(r.recordingRule)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for rule.
+func (r *rule) UnmarshalJSON(b []byte) error {
+	var ruleType struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(b, &ruleType); err != nil {
+		return err
+	}
+	switch ruleType.Type {
+	case "alerting":
+		var alertingr alertingRule
+		if err := json.Unmarshal(b, &alertingr); err != nil {
+			return err
+		}
+		r.alertingRule = &alertingr
+	case "recording":
+		var recordingr recordingRule
+		if err := json.Unmarshal(b, &recordingr); err != nil {
+			return err
+		}
+		r.recordingRule = &recordingr
+	default:
+		return fmt.Errorf("failed to unmarshal rule: unknown type %q", ruleType.Type)
+	}
+
+	return nil
+}
+
+type alertingRule struct {
+	Name        string        `json:"name"`
+	Query       string        `json:"query"`
+	Duration    float64       `json:"duration"`
+	Labels      labels.Labels `json:"labels"`
+	Annotations labels.Labels `json:"annotations"`
+	Alerts      []*alert      `json:"alerts"`
+	Health      string        `json:"health"`
+	LastError   string        `json:"lastError,omitempty"`
+	// Type of an alertingRule is always "alerting".
+	Type string `json:"type"`
+}
+
+type recordingRule struct {
+	Name      string        `json:"name"`
+	Query     string        `json:"query"`
+	Labels    labels.Labels `json:"labels,omitempty"`
+	Health    string        `json:"health"`
+	LastError string        `json:"lastError,omitempty"`
+	// Type of a recordingRule is always "recording".
+	Type string `json:"type"`
+}
+
+type alert struct {
+	Labels      labels.Labels `json:"labels"`
+	Annotations labels.Labels `json:"annotations"`
+	State       string        `json:"state"`
+	ActiveAt    *time.Time    `json:"activeAt,omitempty"`
+	Value       string        `json:"value"`
+}
+
+func (r *routes) rules(resp *http.Response) error {
+	if resp.StatusCode != http.StatusOK {
+		// Pass non-200 responses as-is.
+		return nil
+	}
+
+	apir, err := getAPIResponse(resp)
+	if err != nil {
+		return errors.Wrap(err, "can't decode API response")
+	}
+
+	var rgs rulesData
+	if err := json.Unmarshal([]byte(apir.Data), &rgs); err != nil {
+		return errors.Wrap(err, "can't decode rules data")
+	}
+
+	lvalue := mustLabelValue(resp.Request.Context())
+	filtered := []*ruleGroup{}
+	for _, rg := range rgs.RuleGroups {
+		var rules []rule
+		for _, rule := range rg.Rules {
+			for _, lbl := range rule.Labels() {
+				if lbl.Name == r.label && lbl.Value == lvalue {
+					rules = append(rules, rule)
+					break
+				}
+			}
+		}
+		if len(rules) > 0 {
+			rg.Rules = rules
+			filtered = append(filtered, rg)
+		}
+	}
+
+	if err := apir.setData(&rulesData{RuleGroups: filtered}); err != nil {
+		return errors.Wrap(err, "can't set rules data")
+	}
+
+	var buf bytes.Buffer
+	if err = json.NewEncoder(&buf).Encode(apir); err != nil {
+		return errors.Wrap(err, "can't encode API response")
+	}
+	resp.Body = ioutil.NopCloser(&buf)
+	resp.Header["Content-Length"] = []string{fmt.Sprint(buf.Len())}
+
+	return nil
+}

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -1,0 +1,592 @@
+package injectproxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func validRules() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`{
+  "status": "success",
+  "data": {
+    "groups": [
+      {
+        "name": "group1",
+        "file": "testdata/rules1.yml",
+        "rules": [
+          {
+            "name": "metric1",
+            "query": "0",
+            "labels": {
+              "namespace": "ns1"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "1",
+            "labels": {
+              "namespace": "ns1",
+              "operation": "create"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "0",
+            "labels": {
+              "namespace": "ns1",
+              "operation": "update"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "0",
+            "labels": {
+              "namespace": "ns1",
+              "operation": "delete"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "Alert1",
+            "query": "metric1{namespace=\"ns1\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns1"
+            },
+            "annotations": {},
+            "alerts": [
+              {
+                "labels": {
+                  "alertname": "Alert1",
+                  "namespace": "ns1"
+                },
+                "annotations": {},
+                "state": "firing",
+                "activeAt": "2019-12-18T13:14:44.543981127+01:00",
+                "value": "0e+00"
+              }
+            ],
+            "health": "ok",
+            "type": "alerting"
+          },
+          {
+            "name": "Alert2",
+            "query": "metric2{namespace=\"ns1\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns1"
+            },
+            "annotations": {},
+            "alerts": [
+              {
+                "labels": {
+                  "alertname": "Alert2",
+                  "namespace": "ns1",
+                  "operation": "update"
+                },
+                "annotations": {},
+                "state": "firing",
+                "activeAt": "2019-12-18T13:14:44.543981127+01:00",
+                "value": "0e+00"
+              },
+              {
+                "labels": {
+                  "alertname": "Alert2",
+                  "namespace": "ns1",
+                  "operation": "delete"
+                },
+                "annotations": {},
+                "state": "firing",
+                "activeAt": "2019-12-18T13:14:44.543981127+01:00",
+                "value": "0e+00"
+              }
+            ],
+            "health": "ok",
+            "type": "alerting"
+          }
+        ],
+        "interval": 10
+      },
+      {
+        "name": "group1",
+        "file": "testdata/rules2.yml",
+        "rules": [
+          {
+            "name": "metric1",
+            "query": "1",
+            "labels": {
+              "namespace": "ns2"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "Alert1",
+            "query": "metric1{namespace=\"ns2\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns2"
+            },
+            "annotations": {},
+            "alerts": [],
+            "health": "ok",
+            "type": "alerting"
+          }
+        ],
+        "interval": 10
+      },
+      {
+        "name": "group2",
+        "file": "testdata/rules2.yml",
+        "rules": [
+          {
+            "name": "metric2",
+            "query": "1",
+            "labels": {
+              "namespace": "ns2",
+              "operation": "create"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "2",
+            "labels": {
+              "namespace": "ns2",
+              "operation": "update"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "3",
+            "labels": {
+              "namespace": "ns2",
+              "operation": "delete"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric3",
+            "query": "0",
+            "labels": {
+              "namespace": "ns2"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "Alert2",
+            "query": "metric2{namespace=\"ns2\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns2"
+            },
+            "annotations": {},
+            "alerts": [],
+            "health": "ok",
+            "type": "alerting"
+          },
+          {
+            "name": "Alert3",
+            "query": "metric3{namespace=\"ns2\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns2"
+            },
+            "annotations": {},
+            "alerts": [
+              {
+                "labels": {
+                  "alertname": "Alert3",
+                  "namespace": "ns2"
+                },
+                "annotations": {},
+                "state": "firing",
+                "activeAt": "2019-12-18T13:14:39.972915521+01:00",
+                "value": "0e+00"
+              }
+            ],
+            "health": "ok",
+            "type": "alerting"
+          }
+        ],
+        "interval": 10
+      }
+    ]
+  }
+}`))
+	})
+}
+
+func TestRules(t *testing.T) {
+	for _, tc := range []struct {
+		labelv   string
+		upstream http.Handler
+
+		expCode int
+		expBody []byte
+	}{
+		{
+			// No "namespace" parameter returns an error.
+			expCode: http.StatusBadRequest,
+			expBody: []byte("Bad request. The \"namespace\" query parameter must be provided.\n"),
+		},
+		{
+			// non 200 status code from upstream is passed as-is.
+			labelv: "upstream_error",
+			upstream: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("error"))
+			}),
+
+			expCode: http.StatusBadRequest,
+			expBody: []byte("error"),
+		},
+		{
+			// incomplete API response triggers a 502 error.
+			labelv: "incomplete_data_from_upstream",
+			upstream: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte("{"))
+			}),
+
+			expCode: http.StatusBadGateway,
+			expBody: []byte(""),
+		},
+		{
+			// invalid API response triggers a 502 error.
+			labelv: "invalid_data_from_upstream",
+			upstream: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte("0"))
+			}),
+
+			expCode: http.StatusBadGateway,
+			expBody: []byte(""),
+		},
+		{
+			// "namespace" parameter matching no rule.
+			labelv:   "not_present",
+			upstream: validRules(),
+
+			expCode: http.StatusOK,
+			expBody: []byte(`{
+  "status": "success",
+  "data": {
+    "groups": []
+  }
+}`),
+		},
+		{
+			labelv:   "ns1",
+			upstream: validRules(),
+
+			expCode: http.StatusOK,
+			expBody: []byte(`{
+  "status": "success",
+  "data": {
+    "groups": [
+      {
+        "name": "group1",
+        "file": "testdata/rules1.yml",
+        "rules": [
+          {
+            "name": "metric1",
+            "query": "0",
+            "labels": {
+              "namespace": "ns1"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "1",
+            "labels": {
+              "namespace": "ns1",
+              "operation": "create"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "0",
+            "labels": {
+              "namespace": "ns1",
+              "operation": "update"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "0",
+            "labels": {
+              "namespace": "ns1",
+              "operation": "delete"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "Alert1",
+            "query": "metric1{namespace=\"ns1\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns1"
+            },
+            "annotations": {},
+            "alerts": [
+              {
+                "labels": {
+                  "alertname": "Alert1",
+                  "namespace": "ns1"
+                },
+                "annotations": {},
+                "state": "firing",
+                "activeAt": "2019-12-18T13:14:44.543981127+01:00",
+                "value": "0e+00"
+              }
+            ],
+            "health": "ok",
+            "type": "alerting"
+          },
+          {
+            "name": "Alert2",
+            "query": "metric2{namespace=\"ns1\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns1"
+            },
+            "annotations": {},
+            "alerts": [
+              {
+                "labels": {
+                  "alertname": "Alert2",
+                  "namespace": "ns1",
+                  "operation": "update"
+                },
+                "annotations": {},
+                "state": "firing",
+                "activeAt": "2019-12-18T13:14:44.543981127+01:00",
+                "value": "0e+00"
+              },
+              {
+                "labels": {
+                  "alertname": "Alert2",
+                  "namespace": "ns1",
+                  "operation": "delete"
+                },
+                "annotations": {},
+                "state": "firing",
+                "activeAt": "2019-12-18T13:14:44.543981127+01:00",
+                "value": "0e+00"
+              }
+            ],
+            "health": "ok",
+            "type": "alerting"
+          }
+        ],
+        "interval": 10
+      }
+    ]
+  }
+}`),
+		},
+		{
+			labelv:   "ns2",
+			upstream: validRules(),
+
+			expCode: http.StatusOK,
+			expBody: []byte(`{
+  "status": "success",
+  "data": {
+    "groups": [
+      {
+        "name": "group1",
+        "file": "testdata/rules2.yml",
+        "rules": [
+          {
+            "name": "metric1",
+            "query": "1",
+            "labels": {
+              "namespace": "ns2"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "Alert1",
+            "query": "metric1{namespace=\"ns2\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns2"
+            },
+            "annotations": {},
+            "alerts": [],
+            "health": "ok",
+            "type": "alerting"
+          }
+        ],
+        "interval": 10
+      },
+      {
+        "name": "group2",
+        "file": "testdata/rules2.yml",
+        "rules": [
+          {
+            "name": "metric2",
+            "query": "1",
+            "labels": {
+              "namespace": "ns2",
+              "operation": "create"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "2",
+            "labels": {
+              "namespace": "ns2",
+              "operation": "update"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric2",
+            "query": "3",
+            "labels": {
+              "namespace": "ns2",
+              "operation": "delete"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "metric3",
+            "query": "0",
+            "labels": {
+              "namespace": "ns2"
+            },
+            "health": "ok",
+            "type": "recording"
+          },
+          {
+            "name": "Alert2",
+            "query": "metric2{namespace=\"ns2\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns2"
+            },
+            "annotations": {},
+            "alerts": [],
+            "health": "ok",
+            "type": "alerting"
+          },
+          {
+            "name": "Alert3",
+            "query": "metric3{namespace=\"ns2\"} == 0",
+            "duration": 0,
+            "labels": {
+              "namespace": "ns2"
+            },
+            "annotations": {},
+            "alerts": [
+              {
+                "labels": {
+                  "alertname": "Alert3",
+                  "namespace": "ns2"
+                },
+                "annotations": {},
+                "state": "firing",
+                "activeAt": "2019-12-18T13:14:39.972915521+01:00",
+                "value": "0e+00"
+              }
+            ],
+            "health": "ok",
+            "type": "alerting"
+          }
+        ],
+        "interval": 10
+      }
+    ]
+  }
+}`),
+		},
+	} {
+		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
+			m := newMockUpstream(tc.upstream)
+			defer m.Close()
+			r := NewRoutes(m.url, proxyLabel)
+
+			u, err := url.Parse("http://prometheus.example.com/api/v1/rules")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			q := u.Query()
+			q.Set(proxyLabel, tc.labelv)
+			u.RawQuery = q.Encode()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", u.String(), nil)
+			r.ServeHTTP(w, req)
+
+			resp := w.Result()
+
+			if resp.StatusCode != tc.expCode {
+				t.Fatalf("expected status code %d, got %d", tc.expCode, resp.StatusCode)
+			}
+
+			body, _ := ioutil.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				if string(body) != string(tc.expBody) {
+					t.Fatalf("expected: %q, got: %q", string(tc.expBody), string(body))
+				}
+				return
+			}
+
+			// We need to unmarshal/marshal the result to run deterministic comparisons.
+			got := normalizeAPIResponse(t, body)
+			expected := normalizeAPIResponse(t, tc.expBody)
+			if got != expected {
+				t.Logf("expected:")
+				t.Logf(expected)
+				t.Logf("got:")
+				t.Logf(got)
+				t.FailNow()
+			}
+		})
+	}
+}
+
+func normalizeAPIResponse(t *testing.T, b []byte) string {
+	t.Helper()
+	var apir apiResponse
+	if err := json.Unmarshal(b, &apir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out, err := json.MarshalIndent(&apir, "", "  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	return string(out)
+}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/signal"
@@ -48,9 +47,9 @@ func main() {
 		log.Fatalf("Failed to build parse upstream URL: %v", err)
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
+	routes := injectproxy.NewRoutes(upstreamURL, label)
 	mux := http.NewServeMux()
-	mux.Handle("/", injectproxy.NewRoutes(proxy, label))
+	mux.Handle("/", routes)
 
 	srv := &http.Server{Handler: mux}
 


### PR DESCRIPTION
This change revisits heavily `injectproxy.routes` because prom-label-proxy needs to filter rules from the upstream's response rather than hacking/injecting query parameters in the incoming request. Hopefully the unit tests should make sure that there's no regression.