### PR TITLE
injectproxy/routes.go fix imports order

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -3,12 +3,12 @@ package injectproxy
 import (
 	"context"
 	"fmt"
-	"github.com/prometheus/prometheus/promql/parser"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
 )
 
 type routes struct {


### PR DESCRIPTION
This commit simply fixes the order of imports, which was recently
modified in 4fd7fe13454fa68789b89781f6e3ec10bdfb8400.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>