### PR TITLE
Updating prom-label-proxy builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,11 +1,11 @@
 # FROM directives are overriden by CI system (both Prow CI and OSBS)
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 WORKDIR /go/src/github.com/openshift/prom-label-proxy
 COPY . .
 RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make build
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 COPY --from=builder /go/src/github.com/openshift/prom-label-proxy/prom-label-proxy /usr/bin/prom-label-proxy
 
 LABEL io.k8s.display-name="" \


### PR DESCRIPTION
Updating prom-label-proxy builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/prom-label-proxy.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
