### PR TITLE
Fully support POST: enforceLabel/matcher/labelAPI (#55) (#70)

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -138,7 +138,7 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 
 	if opt.enableLabelAPIs {
 		errs.Add(
-			mux.Handle("/api/v1/labels", r.enforceLabel(enforceMethods(r.matcher, "GET"))),
+			mux.Handle("/api/v1/labels", r.enforceLabel(enforceMethods(r.matcher, "GET", "POST"))),
 			// Full path is /api/v1/label/<label_name>/values but http mux does not support patterns.
 			// This is fine though as we don't care about name for matcher injector.
 			mux.Handle("/api/v1/label/", r.enforceLabel(enforceMethods(r.matcher, "GET"))),
@@ -186,7 +186,7 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 
 func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		lvalue := req.URL.Query().Get(r.label)
+		lvalue := req.FormValue(r.label)
 		if lvalue == "" {
 			http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
 			return
@@ -195,8 +195,19 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 
 		// Remove the proxy label from the query parameters.
 		q := req.URL.Query()
-		q.Del(r.label)
+		if q.Get(r.label) != "" {
+			q.Del(r.label)
+		}
 		req.URL.RawQuery = q.Encode()
+		// Remove the proxy label from the PostForm.
+		if req.PostForm.Get(r.label) != "" {
+			req.PostForm.Del(r.label)
+			newBody := req.PostForm.Encode()
+			// We are replacing request body, close previous one (req.FormValue ensures it is read fully and not nil).
+			_ = req.Body.Close()
+			req.Body = ioutil.NopCloser(strings.NewReader(newBody))
+			req.ContentLength = int64(len(newBody))
+		}
 
 		h.ServeHTTP(w, req)
 	})
@@ -321,8 +332,26 @@ func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
 		Type:  labels.MatchEqual,
 		Value: mustLabelValue(req.Context()),
 	}
-
 	q := req.URL.Query()
+	if err := injectMatcher(q, matcher); err != nil {
+		return
+	}
+	req.URL.RawQuery = q.Encode()
+	if req.Method == http.MethodPost {
+		q = req.PostForm
+		if err := injectMatcher(q, matcher); err != nil {
+			return
+		}
+		// We are replacing request body, close previous one (ParseForm ensures it is read fully and not nil).
+		_ = req.Body.Close()
+		newBody := q.Encode()
+		req.Body = ioutil.NopCloser(strings.NewReader(newBody))
+		req.ContentLength = int64(len(newBody))
+	}
+	r.handler.ServeHTTP(w, req)
+}
+
+func injectMatcher(q url.Values, matcher *labels.Matcher) error {
 	matchers := q[matchersParam]
 	if len(matchers) == 0 {
 		q.Set(matchersParam, matchersToString(matcher))
@@ -331,15 +360,13 @@ func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
 		for i, m := range matchers {
 			ms, err := parser.ParseMetricSelector(m)
 			if err != nil {
-				return
+				return err
 			}
 			matchers[i] = matchersToString(append(ms, matcher)...)
 		}
 		q[matchersParam] = matchers
 	}
-
-	req.URL.RawQuery = q.Encode()
-	r.handler.ServeHTTP(w, req)
+	return nil
 }
 
 func matchersToString(ms ...*labels.Matcher) string {

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -43,7 +43,23 @@ func checkParameterAbsent(param string, next http.Handler) http.Handler {
 	})
 }
 
-// checkQueryHandler verifies that the request contains the given parameter key/values.
+func checkFormParameterAbsent(param string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		err := req.ParseForm()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
+			return
+		}
+		kvs := req.Form
+		if len(kvs[param]) != 0 {
+			http.Error(w, fmt.Sprintf("unexpected Form parameter %q", param), http.StatusInternalServerError)
+			return
+		}
+		next.ServeHTTP(w, req)
+	})
+}
+
+// checkQueryHandler verifies that the request form contains the given parameter key/values.
 func checkQueryHandler(body, key string, values ...string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		kvs, err := url.ParseQuery(req.URL.RawQuery)
@@ -72,6 +88,33 @@ func checkQueryHandler(body, key string, values ...string) http.Handler {
 		if string(buf) != body {
 			http.Error(w, fmt.Sprintf("expected body %q, got %q", body, string(buf)), http.StatusInternalServerError)
 			return
+		}
+		w.Write(okResponse)
+		<-time.After(100)
+	})
+}
+
+// checkFormHandler verifies that the request Form contains the given parameter key/values.
+func checkFormHandler(key string, values ...string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		err := req.ParseForm()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
+			return
+		}
+		kvs := req.PostForm
+		// Verify that the client provides the parameter only once.
+		if len(kvs[key]) != len(values) {
+			http.Error(w, fmt.Sprintf("expected %d values of parameter %q, got %d", len(values), key, len(kvs[key])), http.StatusInternalServerError)
+			return
+		}
+		sort.Strings(values)
+		sort.Strings(kvs[key])
+		for i := range values {
+			if kvs[key][i] != values[i] {
+				http.Error(w, fmt.Sprintf("expected parameter %q with value %q, got %q", key, values[i], kvs[key][i]), http.StatusInternalServerError)
+				return
+			}
 		}
 		w.Write(okResponse)
 		<-time.After(100)
@@ -289,6 +332,103 @@ func TestMatch(t *testing.T) {
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", u.String(), nil)
+				r.ServeHTTP(w, req)
+
+				resp := w.Result()
+				body, _ := ioutil.ReadAll(resp.Body)
+				defer resp.Body.Close()
+
+				if resp.StatusCode != tc.expCode {
+					t.Logf("expected status code %d, got %d", tc.expCode, resp.StatusCode)
+					t.Logf("%s", string(body))
+					t.FailNow()
+				}
+				if resp.StatusCode != http.StatusOK {
+					return
+				}
+
+				if string(body) != string(tc.expBody) {
+					t.Fatalf("expected body %q, got %q", string(tc.expBody), string(body))
+				}
+			})
+		}
+	}
+}
+
+func TestMatchWithPost(t *testing.T) {
+	for _, tc := range []struct {
+		labelv  string
+		matches []string
+
+		expCode  int
+		expMatch []string
+		expBody  []byte
+	}{
+		{
+			// No "namespace" parameter returns an error.
+			expCode: http.StatusBadRequest,
+		},
+		{
+			// No "match" parameter.
+			labelv:   "default",
+			expCode:  http.StatusOK,
+			expMatch: []string{`{namespace="default"}`},
+			expBody:  okResponse,
+		},
+		{
+			// Single "match" parameters.
+			labelv:   "default",
+			matches:  []string{`{job="prometheus",__name__=~"job:.*"}`},
+			expCode:  http.StatusOK,
+			expMatch: []string{`{job="prometheus",__name__=~"job:.*",namespace="default"}`},
+			expBody:  okResponse,
+		},
+		{
+			// Single "match" parameters with label dup name.
+			labelv:   "default",
+			matches:  []string{`{job="prometheus",__name__=~"job:.*",namespace="default"}`},
+			expCode:  http.StatusOK,
+			expMatch: []string{`{job="prometheus",__name__=~"job:.*",namespace="default",namespace="default"}`},
+			expBody:  okResponse,
+		},
+		{
+			// Many "match" parameters.
+			labelv:   "default",
+			matches:  []string{`{job="prometheus"}`, `{__name__=~"job:.*"}`},
+			expCode:  http.StatusOK,
+			expMatch: []string{`{job="prometheus",namespace="default"}`, `{__name__=~"job:.*",namespace="default"}`},
+			expBody:  okResponse,
+		},
+	} {
+		for _, u := range []string{
+			"http://prometheus.example.com/api/v1/labels",
+		} {
+			t.Run(fmt.Sprintf("%s?match[]=%s", u, strings.Join(tc.matches, "&")), func(t *testing.T) {
+				m := newMockUpstream(
+					checkFormParameterAbsent(
+						proxyLabel,
+						checkFormHandler(matchersParam, tc.expMatch...),
+					),
+				)
+				defer m.Close()
+				r, err := NewRoutes(m.url, proxyLabel, WithEnabledLabelsAPI())
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				u, err := url.Parse(u)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				q := url.Values{}
+				for _, m := range tc.matches {
+					q.Add(matchersParam, m)
+				}
+				q.Set(proxyLabel, tc.labelv)
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodPost, u.String(), strings.NewReader(q.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				r.ServeHTTP(w, req)
 
 				resp := w.Result()


### PR DESCRIPTION
Cherry pick https://github.com/prometheus-community/prom-label-proxy/pull/70

* Fully support POST: enforceLabel/matcher/labelAPI (#55)

Signed-off-by: hanjm <hanjinming@outlook.com>

* Always override req.URL.RawQuery when process matcher

Signed-off-by: hanjm <hanjinming@outlook.com>

* Revert modify req.Form

Signed-off-by: hanjm <hanjinming@outlook.com>